### PR TITLE
feat: add GetRawSrcKey method to Client interface and implementations

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -84,6 +84,14 @@ func (a *S3) Copy(ctx context.Context, srcKey, dstKey string, options ...CopyOpt
 	return nil
 }
 
+func (a *S3) GetRawSrcKey(ctx context.Context, key string) (string, error) {
+	bucketName, fullKey, err := a.getBucketAndKey(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/%s/%s", bucketName, fullKey), nil
+}
+
 func (a *S3) GetBucketName(ctx context.Context, key string) (string, error) {
 	bucketName, _, err := a.getBucketAndKey(ctx, key)
 	return bucketName, err

--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ const PackageName = "component.eoss"
 
 // Client object storage client interface
 type Client interface {
+	GetRawSrcKey(ctx context.Context, key string) (string, error)
 	GetBucketName(ctx context.Context, key string) (string, error)
 	Get(ctx context.Context, key string, options ...GetOptions) (string, error)
 	GetBytes(ctx context.Context, key string, options ...GetOptions) ([]byte, error)

--- a/component.go
+++ b/component.go
@@ -34,6 +34,10 @@ func (c *Component) Copy(ctx context.Context, srcKey, dstKey string, options ...
 	return c.defaultClient.Copy(ctx, srcKey, dstKey, options...)
 }
 
+func (c *Component) GetRawSrcKey(ctx context.Context, key string) (string, error) {
+	return c.defaultClient.GetRawSrcKey(ctx, key)
+}
+
 func (c *Component) GetBucketName(ctx context.Context, key string) (string, error) {
 	return c.defaultClient.GetBucketName(ctx, key)
 }

--- a/local_file.go
+++ b/local_file.go
@@ -33,6 +33,10 @@ func NewLocalFile(path string) (*LocalFile, error) {
 	}, err
 }
 
+func (l *LocalFile) GetRawSrcKey(ctx context.Context, key string) (string, error) {
+	panic("implement me")
+}
+
 func (l *LocalFile) GetBucketName(ctx context.Context, key string) (string, error) {
 	panic("implement me")
 }

--- a/oss.go
+++ b/oss.go
@@ -85,6 +85,14 @@ func (ossClient *OSS) Copy(ctx context.Context, srcKey, dstKey string, options .
 	return nil
 }
 
+func (ossClient *OSS) GetRawSrcKey(ctx context.Context, key string) (string, error) {
+	b, fullKey, err := ossClient.getBucket(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/%s/%s", b.BucketName, fullKey), nil
+}
+
 func (ossClient *OSS) GetBucketName(ctx context.Context, key string) (string, error) {
 	b, _, err := ossClient.getBucket(ctx, key)
 	if err != nil {


### PR DESCRIPTION
### 变更背景

在使用 ‎`Copy()` API 时，通过 ‎`CopyWithRawSrcKey()` option，可以让业务在跨桶复制场景下，直接指定包含 bucket 信息的原始 key。由于每个 client 实例与单独的 bucket 绑定，未使用 ‎`CopyWithRawSrcKey()` 时，无法在同一个 client 内获取多个 bucket 的 key。
虽然业务层可以指定带有 bucket 的 rawKey，但原有 client 实现没有暴露获取带前缀 key 的方法，导致无法获取完整的 raw key 路径。

### 主要变更
 • 新增 ‎`GetRawSrcKey(ctx, key)` 到 ‎`Client` 接口。
 • 在 S3 和 OSS 实现中补充该方法，返回 ‎`/<bucket>/<prefixed-key>` 格式的完整路径。

### 影响评估
 • 纯新增，向后兼容，不影响现有功能。
 • 方便业务层获取 bucket + key 的完整路径，便于应对复杂的跨桶复制场景。